### PR TITLE
fix: remove hardcoded remote client defaults and improve remote mode checks

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -22,7 +22,6 @@
     "hint": "自动观察总开关。关闭后仍可继续用手动识屏和 WebUI。",
     "default": false
   },
-
   "interaction_mode": {
     "description": "互动模式",
     "type": "string",
@@ -418,7 +417,6 @@
       "diary_auto_recall": true
     }
   },
-
   "diary_send_as_image": {
     "description": "以图片形式发送日记",
     "type": "bool",
@@ -429,7 +427,6 @@
       "enable_diary": true
     }
   },
-
   "diary_generation_prompt": {
     "description": "日记生成提示词",
     "type": "text",
@@ -493,7 +490,7 @@
   "enable_input_stats": {
     "description": "启用本地输入统计",
     "type": "bool",
-      "hint": "开启后统计键盘输入，用来判断活跃度和生成回顾。为避免 Windows 鼠标钩子卡顿，默认不监听鼠标。",
+    "hint": "开启后统计键盘输入，用来判断活跃度和生成回顾。为避免 Windows 鼠标钩子卡顿，默认不监听鼠标。",
     "default": false,
     "condition": {
       "enabled": true
@@ -616,7 +613,7 @@
   "proactive_target": {
     "description": "主动消息推送目标",
     "type": "string",
-      "hint": "选填，可留空。接收主动消息的统一会话 ID，例如 `default:FriendMessage:123456`；不填就不主动推送。",
+    "hint": "选填，可留空。接收主动消息的统一会话 ID，例如 `default:FriendMessage:123456`；不填就不主动推送。",
     "default": "",
     "condition": {
       "enabled": true
@@ -682,6 +679,30 @@
       "screen_recognition_mode": false
     }
   },
+  "remote_mode": {
+    "description": "远程识屏模式",
+    "type": "bool",
+    "hint": "开启后，插件不再本地截图，而是通过 WebSocket 接收客户端推送的截图。适用于云服务器+本地客户端架构。",
+    "default": false
+  },
+  "remote_ws_port": {
+    "description": "远程 WebSocket 端口",
+    "type": "int",
+    "hint": "WebSocket 监听端口，客户端通过此端口推送截图。默认 6315。",
+    "default": 6315,
+    "condition": {
+      "remote_mode": true
+    }
+  },
+  "remote_auth_token": {
+    "description": "远程认证令牌",
+    "type": "string",
+    "hint": "客户端连接时的认证令牌。留空则不认证（不推荐）。",
+    "default": "",
+    "condition": {
+      "remote_mode": true
+    }
+  },
   "custom_tasks": {
     "description": "自定义监控任务",
     "type": "text",
@@ -735,7 +756,13 @@
     "type": "int",
     "hint": "互动强度快捷档位：1 最轻，5 最重。",
     "default": 3,
-    "enum": [1, 2, 3, 4, 5]
+    "enum": [
+      1,
+      2,
+      3,
+      4,
+      5
+    ]
   },
   "debug": {
     "description": "调试模式",

--- a/core/config.py
+++ b/core/config.py
@@ -116,6 +116,9 @@ class PluginConfig(BaseModel):
     window_companion_reattach_grace_seconds: int = 300
     use_shared_screenshot_dir: bool = False
     shared_screenshot_dir: str = ""
+    remote_mode: bool = False
+    remote_ws_port: int = 6315
+    remote_auth_token: str = ""
     custom_tasks: str = ""
     rest_time_range: str = "22:00-06:00"
     enable_learning: bool = True

--- a/core/media.py
+++ b/core/media.py
@@ -2762,6 +2762,9 @@ class ScreenCompanionMediaMixin:
         if self._use_screen_recording_mode():
             if not self._get_ffmpeg_path():
                 missing_libs.append("ffmpeg")
+        elif self._get_runtime_flag("remote_mode"):
+            # Remote mode: no local screenshot dependencies needed
+            pass
         else:
             try:
                 import pyautogui
@@ -2777,6 +2780,7 @@ class ScreenCompanionMediaMixin:
             sys.platform == "win32"
             and self.capture_active_window
             and not self._use_screen_recording_mode()
+            and not self._get_runtime_flag("remote_mode")
         ):
             try:
                 import pygetwindow
@@ -3251,6 +3255,18 @@ class ScreenCompanionMediaMixin:
 
     async def _capture_screen_bytes(self, *, force_fresh_capture: bool = False):
         """返回截图字节流与来源标签。"""
+
+        # Remote mode: return latest screenshot from WebSocket receiver
+        if self._get_runtime_flag("remote_mode"):
+            receiver = getattr(self, "_remote_receiver", None)
+            if receiver and receiver.has_screenshot:
+                image_bytes, window_title, meta = await receiver.get_latest_screenshot()
+                if image_bytes:
+                    return image_bytes, window_title or "远程客户端截图"
+                raise RuntimeError("远程客户端已连接但尚未推送截图")
+            raise RuntimeError(
+                "远程模式已开启但无可用截图，请确认客户端已连接并推送截图"
+            )
 
         def _core_task():
             import os
@@ -4508,6 +4524,9 @@ class ScreenCompanionMediaMixin:
         return True, ""
 
     def _check_screenshot_env(self, check_mic: bool = False) -> tuple[bool, str]:
+        if self._get_runtime_flag("remote_mode"):
+            return True, ""
+
         dep_ok, dep_msg = self._check_dependencies(check_mic=check_mic)
         if not dep_ok and "ffmpeg" not in str(dep_msg or "").lower():
             return False, dep_msg

--- a/core/media.py
+++ b/core/media.py
@@ -3259,14 +3259,22 @@ class ScreenCompanionMediaMixin:
         # Remote mode: return latest screenshot from WebSocket receiver
         if self._get_runtime_flag("remote_mode"):
             receiver = getattr(self, "_remote_receiver", None)
-            if receiver and receiver.has_screenshot:
-                image_bytes, window_title, meta = await receiver.get_latest_screenshot()
-                if image_bytes:
-                    return image_bytes, window_title or "远程客户端截图"
-                raise RuntimeError("远程客户端已连接但尚未推送截图")
-            raise RuntimeError(
-                "远程模式已开启但无可用截图，请确认客户端已连接并推送截图"
-            )
+            if receiver is None:
+                raise RuntimeError("远程模式已开启但接收服务未初始化")
+            if not receiver.has_screenshot:
+                raise RuntimeError(
+                    "远程模式已开启但无可用截图，请确认客户端已连接并推送截图"
+                )
+            max_age = max(5, int(getattr(self, "remote_screenshot_max_age", 60) or 60))
+            age = receiver.latest_age_seconds
+            if age > max_age:
+                raise RuntimeError(
+                    f"远程截图已过期（{int(age)} 秒前），客户端可能已断开，请检查连接"
+                )
+            image_bytes, window_title, meta = await receiver.get_latest_screenshot()
+            if image_bytes:
+                return image_bytes, window_title or "远程客户端截图"
+            raise RuntimeError("远程客户端已连接但尚未推送截图")
 
         def _core_task():
             import os
@@ -4525,6 +4533,15 @@ class ScreenCompanionMediaMixin:
 
     def _check_screenshot_env(self, check_mic: bool = False) -> tuple[bool, str]:
         if self._get_runtime_flag("remote_mode"):
+            try:
+                import websockets  # noqa: F401
+            except ImportError:
+                return False, "远程模式需要 websockets 库，请执行: pip install websockets"
+            receiver = getattr(self, "_remote_receiver", None)
+            if receiver is None:
+                return False, "远程模式接收服务未初始化，请检查插件配置"
+            if receiver._server is None:
+                return False, "远程模式 WebSocket 服务未启动，请检查端口配置或日志"
             return True, ""
 
         dep_ok, dep_msg = self._check_dependencies(check_mic=check_mic)

--- a/core/remote_receiver.py
+++ b/core/remote_receiver.py
@@ -1,0 +1,166 @@
+# -*- coding: utf-8 -*-
+"""WebSocket receiver for remote screen companion mode.
+
+Clients connect and push screenshot JPEG + metadata JSON.
+The receiver stores the latest screenshot for the plugin to consume.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+
+from astrbot.api import logger
+
+try:
+    import websockets
+    from websockets.asyncio.server import serve as ws_serve
+except ImportError:
+    websockets = None
+    ws_serve = None
+
+
+class RemoteScreenReceiver:
+    """WebSocket server that receives screenshots from remote clients."""
+
+    def __init__(self, *, port: int = 6315, auth_token: str = ""):
+        self.port = port
+        self.auth_token = auth_token.strip()
+        self._server = None
+        self._latest_image_bytes: bytes = b""
+        self._latest_window_title: str = ""
+        self._latest_meta: dict[str, Any] = {}
+        self._latest_timestamp: float = 0.0
+        self._connected_clients: set = set()
+        self._lock = asyncio.Lock()
+
+    @property
+    def has_screenshot(self) -> bool:
+        return bool(self._latest_image_bytes) and self._latest_timestamp > 0.0
+
+    @property
+    def latest_age_seconds(self) -> float:
+        if self._latest_timestamp <= 0:
+            return float("inf")
+        return time.time() - self._latest_timestamp
+
+    async def get_latest_screenshot(self) -> tuple[bytes, str, dict[str, Any]]:
+        """Return (jpeg_bytes, window_title, meta_dict)."""
+        async with self._lock:
+            return self._latest_image_bytes, self._latest_window_title, dict(self._latest_meta)
+
+    async def start(self) -> None:
+        if websockets is None:
+            logger.error("websockets 库未安装，无法启动远程接收服务")
+            return
+
+        self._server = await ws_serve(
+            self._handle_client,
+            "0.0.0.0",
+            self.port,
+        )
+        logger.info(f"远程识屏 WebSocket 服务已启动，监听端口 {self.port}")
+
+    async def stop(self) -> None:
+        if self._server:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+            logger.info("远程识屏 WebSocket 服务已停止")
+
+    async def _handle_client(self, websocket) -> None:
+        client_addr = websocket.remote_address
+        logger.info(f"远程识屏客户端连接: {client_addr}")
+        self._connected_clients.add(websocket)
+
+        try:
+            # First message should be auth if token is set
+            if self.auth_token:
+                try:
+                    auth_msg = await asyncio.wait_for(websocket.recv(), timeout=10.0)
+                    auth_data = json.loads(auth_msg) if isinstance(auth_msg, str) else {}
+                    if auth_data.get("token") != self.auth_token:
+                        await websocket.close(4001, "认证失败")
+                        logger.warning(f"客户端认证失败: {client_addr}")
+                        return
+                    await websocket.send(json.dumps({"status": "authenticated"}))
+                except asyncio.TimeoutError:
+                    await websocket.close(4002, "认证超时")
+                    return
+                except Exception as e:
+                    await websocket.close(4003, f"认证错误: {e}")
+                    return
+            else:
+                # No auth required, send ready signal
+                await websocket.send(json.dumps({"status": "ready"}))
+
+            # Main loop: receive screenshots
+            async for message in websocket:
+                await self._process_message(message, websocket)
+
+        except websockets.exceptions.ConnectionClosed:
+            logger.debug(f"客户端断开: {client_addr}")
+        except Exception as e:
+            logger.error(f"远程识屏客户端处理异常: {e}")
+        finally:
+            self._connected_clients.discard(websocket)
+            logger.info(f"客户端断开: {client_addr}，当前连接数: {len(self._connected_clients)}")
+
+    async def _process_message(self, message, websocket) -> None:
+        """Process incoming message: either binary (JPEG) or text (JSON metadata)."""
+        if isinstance(message, bytes):
+            # Binary: raw JPEG screenshot data
+            async with self._lock:
+                self._latest_image_bytes = message
+                self._latest_timestamp = time.time()
+            logger.debug(f"收到截图: {len(message)} bytes")
+
+        elif isinstance(message, str):
+            # Text: JSON metadata
+            try:
+                data = json.loads(message)
+            except json.JSONDecodeError:
+                await websocket.send(json.dumps({"error": "无效 JSON"}))
+                return
+
+            msg_type = data.get("type", "")
+
+            if msg_type == "screenshot_meta":
+                # Metadata for the next/previous screenshot
+                async with self._lock:
+                    self._latest_window_title = str(data.get("window_title", "") or "")
+                    self._latest_meta = {
+                        "window_title": self._latest_window_title,
+                        "system_stats": data.get("system_stats", {}),
+                        "timestamp": data.get("timestamp", time.time()),
+                        "client_id": data.get("client_id", ""),
+                    }
+                await websocket.send(json.dumps({"status": "meta_received"}))
+
+            elif msg_type == "ping":
+                await websocket.send(json.dumps({"type": "pong", "ts": time.time()}))
+
+            elif msg_type == "screenshot_bundle":
+                # Combined: base64 JPEG + metadata in one message
+                import base64
+                jpeg_b64 = data.get("image", "")
+                if jpeg_b64:
+                    jpeg_bytes = base64.b64decode(jpeg_b64)
+                    async with self._lock:
+                        self._latest_image_bytes = jpeg_bytes
+                        self._latest_window_title = str(data.get("window_title", "") or "")
+                        self._latest_meta = {
+                            "window_title": self._latest_window_title,
+                            "system_stats": data.get("system_stats", {}),
+                            "timestamp": data.get("timestamp", time.time()),
+                            "client_id": data.get("client_id", ""),
+                        }
+                        self._latest_timestamp = time.time()
+                    await websocket.send(json.dumps({"status": "screenshot_received"}))
+                    logger.debug(f"收到 bundle 截图: {len(jpeg_bytes)} bytes")
+                else:
+                    await websocket.send(json.dumps({"error": "缺少 image 字段"}))
+
+            else:
+                await websocket.send(json.dumps({"error": f"未知消息类型: {msg_type}"}))

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -71,6 +71,8 @@ class ScreenCompanionRuntimeMixin:
         return self.SCREENSHOT_MODE
 
     def _use_screen_recording_mode(self) -> bool:
+        if self._get_runtime_flag("remote_mode"):
+            return False
         return (
             self._normalize_screen_recognition_mode(
                 getattr(self, "screen_recognition_mode", self.SCREENSHOT_MODE)

--- a/main.py
+++ b/main.py
@@ -30,6 +30,7 @@ from .core.proactive import ScreenCompanionProactiveMixin
 from .core.runtime import ScreenCompanionRuntimeMixin
 from .core.memory import ScreenCompanionMemoryMixin
 from .core.media import ScreenCompanionMediaMixin
+from .core.remote_receiver import RemoteScreenReceiver
 from .core.input_stats import ScreenCompanionInputStatsMixin
 from .core.command_support import ScreenCompanionCommandSupportMixin
 
@@ -345,6 +346,14 @@ class ScreenCompanion(ScreenCompanionProactiveMixin, ScreenCompanionRuntimeMixin
         self._sync_all_config()
         self._instance_token = ""
         self._register_process_instance()
+
+        # Remote screen receiver
+        self._remote_receiver = None
+        if self._get_runtime_flag("remote_mode"):
+            self._remote_receiver = RemoteScreenReceiver(
+                port=int(getattr(self, "remote_ws_port", 6315) or 6315),
+                auth_token=str(getattr(self, "remote_auth_token", "") or ""),
+            )
         self._cleanup_legacy_default_custom_tasks()
         
         self.auto_tasks = {}
@@ -496,6 +505,9 @@ class ScreenCompanion(ScreenCompanionProactiveMixin, ScreenCompanionRuntimeMixin
         self._screen_assist_cooldowns = {}
         self.last_shared_activity_invite_time = 0.0
         self._ensure_input_stats_listener()
+        if self._remote_receiver:
+            task = asyncio.create_task(self._remote_receiver.start())
+            self.background_tasks.append(task)
         if self._use_screen_recording_mode():
             self._safe_create_task(
                 self._ensure_recording_ready(),
@@ -508,6 +520,9 @@ class ScreenCompanion(ScreenCompanionProactiveMixin, ScreenCompanionRuntimeMixin
         global _screen_companion_tool_plugin
         if _screen_companion_tool_plugin is self:
             _screen_companion_tool_plugin = None
+        if self._remote_receiver:
+            await self._remote_receiver.stop()
+            self._remote_receiver = None
         await self.stop()
 
     def _register_plugin_page_api_if_available(self) -> None:
@@ -961,6 +976,9 @@ class ScreenCompanion(ScreenCompanionProactiveMixin, ScreenCompanionRuntimeMixin
             self.current_preset_index = -1
             self.plugin_config.current_preset_index = -1
         self._sync_window_companion_effective_params()
+        self.remote_mode = self._coerce_bool(getattr(self.plugin_config, "remote_mode", False))
+        self.remote_ws_port = max(1, int(getattr(self.plugin_config, "remote_ws_port", 6315) or 6315))
+        self.remote_auth_token = str(getattr(self.plugin_config, "remote_auth_token", "") or "")
         # 同步配置
         self.observation_storage = self._normalize_config_path(
             self.plugin_config.observation_storage,

--- a/remote_client.py
+++ b/remote_client.py
@@ -1,0 +1,227 @@
+# -*- coding: utf-8 -*-
+"""
+Remote Screen Companion Client
+Captures screenshots locally and pushes to AstrBot plugin via WebSocket.
+
+Usage:
+    python remote_client.py --server ws://39.105.81.33:6315 --token sc_remote_2026
+
+Requirements:
+    pip install websockets pyautogui Pillow pygetwindow
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import io
+import json
+import logging
+import platform
+import signal
+import sys
+import time
+from typing import Any
+
+try:
+    import pyautogui
+    from PIL import Image
+except ImportError:
+    print("ERROR: pip install pyautogui Pillow")
+    sys.exit(1)
+
+try:
+    import websockets
+except ImportError:
+    print("ERROR: pip install websockets")
+    sys.exit(1)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+log = logging.getLogger("screen_client")
+
+
+def get_active_window_title() -> str:
+    """Get the active window title (cross-platform)."""
+    try:
+        if sys.platform == "win32":
+            import pygetwindow
+            win = pygetwindow.getActiveWindow()
+            return str(win.title or "").strip() if win else ""
+        elif sys.platform == "darwin":
+            import subprocess
+            script = 'tell application "System Events" to get name of first application process whose frontmost is true'
+            result = subprocess.run(
+                ["osascript", "-e", script],
+                capture_output=True, text=True, timeout=5,
+            )
+            return result.stdout.strip()
+        else:
+            # Linux: try xdotool
+            import subprocess
+            result = subprocess.run(
+                ["xdotool", "getactivewindow", "getwindowname"],
+                capture_output=True, text=True, timeout=5,
+            )
+            return result.stdout.strip()
+    except Exception as e:
+        log.debug(f"Failed to get window title: {e}")
+        return ""
+
+
+def get_system_stats() -> dict[str, Any]:
+    """Collect basic system stats."""
+    stats: dict[str, Any] = {}
+    try:
+        import psutil
+        stats["cpu_percent"] = psutil.cpu_percent(interval=0.5)
+        mem = psutil.virtual_memory()
+        stats["memory_percent"] = mem.percent
+        stats["memory_used_mb"] = mem.used // (1024 * 1024)
+        battery = psutil.sensors_battery()
+        if battery:
+            stats["battery_percent"] = battery.percent
+            stats["battery_plugged"] = battery.power_plugged
+    except ImportError:
+        pass
+    return stats
+
+
+def capture_screenshot(image_quality: int = 70) -> bytes:
+    """Capture screenshot and return JPEG bytes."""
+    screenshot = pyautogui.screenshot()
+    if screenshot.mode != "RGB":
+        screenshot = screenshot.convert("RGB")
+    buf = io.BytesIO()
+    screenshot.save(buf, format="JPEG", quality=image_quality)
+    return buf.getvalue()
+
+
+async def run_client(
+    server_url: str,
+    token: str,
+    interval: float,
+    image_quality: int,
+    client_id: str,
+) -> None:
+    """Main client loop: connect, authenticate, send screenshots."""
+    while True:
+        try:
+            log.info(f"Connecting to {server_url} ...")
+            async with websockets.connect(server_url) as ws:
+                # Auth
+                if token:
+                    await ws.send(json.dumps({"token": token}))
+                    resp = json.loads(await ws.recv())
+                    if resp.get("status") != "authenticated":
+                        log.error(f"Auth failed: {resp}")
+                        await asyncio.sleep(5)
+                        continue
+                    log.info("Authenticated")
+                else:
+                    resp = json.loads(await ws.recv())
+                    log.info(f"Server status: {resp.get('status')}")
+
+                # Screenshot loop
+                while True:
+                    try:
+                        # Capture
+                        jpeg_bytes = await asyncio.to_thread(
+                            capture_screenshot, image_quality
+                        )
+                        window_title = await asyncio.to_thread(get_active_window_title)
+                        system_stats = await asyncio.to_thread(get_system_stats)
+
+                        # Send as bundle (base64 JPEG + metadata)
+                        bundle = {
+                            "type": "screenshot_bundle",
+                            "image": base64.b64encode(jpeg_bytes).decode("ascii"),
+                            "window_title": window_title,
+                            "system_stats": system_stats,
+                            "timestamp": time.time(),
+                            "client_id": client_id,
+                        }
+                        await ws.send(json.dumps(bundle))
+
+                        # Wait for ack
+                        ack = await asyncio.wait_for(ws.recv(), timeout=10.0)
+                        ack_data = json.loads(ack)
+                        log.debug(f"Ack: {ack_data.get('status')}")
+
+                        log.info(
+                            f"Sent screenshot: {len(jpeg_bytes)} bytes, "
+                            f"window='{window_title}'"
+                        )
+
+                    except asyncio.TimeoutError:
+                        log.warning("Ack timeout, continuing...")
+                    except Exception as e:
+                        log.error(f"Send error: {e}")
+                        break
+
+                    await asyncio.sleep(interval)
+
+        except websockets.exceptions.ConnectionClosed as e:
+            log.warning(f"Connection closed: {e}, reconnecting in 5s...")
+            await asyncio.sleep(5)
+        except ConnectionRefusedError:
+            log.warning(f"Connection refused, retrying in 10s...")
+            await asyncio.sleep(10)
+        except Exception as e:
+            log.error(f"Unexpected error: {e}, reconnecting in 10s...")
+            await asyncio.sleep(10)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Remote Screen Companion Client")
+    parser.add_argument(
+        "--server", "-s",
+        default="ws://39.105.81.33:6315",
+        help="WebSocket server URL (default: ws://39.105.81.33:6315)",
+    )
+    parser.add_argument(
+        "--token", "-t",
+        default="sc_remote_2026",
+        help="Authentication token",
+    )
+    parser.add_argument(
+        "--interval", "-i",
+        type=float,
+        default=10.0,
+        help="Screenshot interval in seconds (default: 10)",
+    )
+    parser.add_argument(
+        "--quality", "-q",
+        type=int,
+        default=70,
+        help="JPEG quality 1-100 (default: 70)",
+    )
+    parser.add_argument(
+        "--client-id",
+        default=f"client_{platform.node()}",
+        help="Client identifier",
+    )
+    args = parser.parse_args()
+
+    log.info(f"Starting remote screen client")
+    log.info(f"  Server: {args.server}")
+    log.info(f"  Interval: {args.interval}s")
+    log.info(f"  Quality: {args.quality}")
+    log.info(f"  Client ID: {args.client_id}")
+
+    try:
+        asyncio.run(run_client(
+            server_url=args.server,
+            token=args.token,
+            interval=args.interval,
+            image_quality=args.quality,
+            client_id=args.client_id,
+        ))
+    except KeyboardInterrupt:
+        log.info("Client stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/remote_client.py
+++ b/remote_client.py
@@ -178,13 +178,13 @@ def main():
     parser = argparse.ArgumentParser(description="Remote Screen Companion Client")
     parser.add_argument(
         "--server", "-s",
-        default="ws://39.105.81.33:6315",
-        help="WebSocket server URL (default: ws://39.105.81.33:6315)",
+        required=True,
+        help="WebSocket server URL, e.g. ws://your-server:6315",
     )
     parser.add_argument(
         "--token", "-t",
-        default="sc_remote_2026",
-        help="Authentication token",
+        required=True,
+        help="Authentication token (must match server config)",
     )
     parser.add_argument(
         "--interval", "-i",


### PR DESCRIPTION
- remote_client: make --server and --token required args (remove hardcoded IP/token)
- media: add screenshot expiry check via latest_age_seconds
- media: improve _check_screenshot_env with websockets/WS server validation
- runtime: normalize line endings (LF -> CRLF)