### PR TITLE
feat: handle remote input_stats and mic_volume

### DIFF
--- a/core/input_stats.py
+++ b/core/input_stats.py
@@ -272,6 +272,59 @@ class ScreenCompanionInputStatsMixin:
             self._input_stats_last_event_at = entry["last_event_at"]
             self._input_stats_dirty = True
 
+    def _ingest_remote_input_stats(self, payload: dict[str, Any] | None) -> dict[str, int]:
+        """Apply one remote client input_stats batch into daily counters."""
+        self._ensure_input_stats_state()
+        data = payload if isinstance(payload, dict) else {}
+        keys = max(0, int(data.get("keys", 0) or 0))
+        clicks = max(0, int(data.get("clicks", 0) or 0))
+        scroll_steps = max(0, int(data.get("scroll_steps", 0) or 0))
+        moves = max(0, int(data.get("moves", 0) or 0))
+        move_pixels = max(0, int(data.get("move_pixels", 0) or 0))
+
+        now_dt = datetime.now()
+        ts_raw = data.get("timestamp")
+        try:
+            ts_val = float(ts_raw)
+            if ts_val > 1e12:
+                ts_val = ts_val / 1000.0
+            if abs(time.time() - ts_val) < 7 * 24 * 3600:
+                now_dt = datetime.fromtimestamp(ts_val)
+        except Exception:
+            pass
+
+        if keys:
+            self._record_input_event("keys", keys, now_dt=now_dt)
+        if clicks:
+            self._record_input_event("clicks", clicks, now_dt=now_dt)
+        if scroll_steps:
+            self._record_input_event("scroll_steps", scroll_steps, now_dt=now_dt)
+        if moves or move_pixels:
+            amount = move_pixels if move_pixels > 0 else max(moves, 1)
+            if moves > 0 and move_pixels <= 0:
+                for _ in range(min(moves, 50)):
+                    self._record_input_event("moves", 1, now_dt=now_dt, count_event=False)
+            else:
+                self._record_input_event("moves", max(amount, 1), now_dt=now_dt, count_event=False)
+                if moves > 1:
+                    for _ in range(min(moves - 1, 49)):
+                        self._record_input_event("moves", 1, now_dt=now_dt, count_event=False)
+
+        if keys or clicks or scroll_steps or moves or move_pixels:
+            self._input_stats_last_event_at = now_dt.isoformat()
+            with self._input_stats_lock:
+                entry = self._get_or_create_input_stats_day(now_dt.strftime("%Y-%m-%d"))
+                entry["last_event_at"] = self._input_stats_last_event_at
+                self._input_stats_dirty = True
+
+        return {
+            "keys": keys,
+            "clicks": clicks,
+            "scroll_steps": scroll_steps,
+            "moves": moves,
+            "move_pixels": move_pixels,
+        }
+
     def _handle_input_key_press(self, _key: Any) -> None:
         self._record_input_event("keys", 1)
 
@@ -392,6 +445,84 @@ class ScreenCompanionInputStatsMixin:
 
     def _get_input_presence_snapshot(self) -> dict[str, Any]:
         self._ensure_input_stats_state()
+
+        # Remote mode cannot observe local keyboard hooks in the container.
+        # Prefer remote screenshot freshness / client connection as presence signal,
+        # otherwise away-auto-pause will immediately suspend after /kps using stale
+        # historical input_stats timestamps.
+        remote_mode = False
+        try:
+            remote_mode = bool(
+                self._get_runtime_flag("remote_mode")
+                if hasattr(self, "_get_runtime_flag")
+                else getattr(self, "remote_mode", False)
+            )
+        except Exception:
+            remote_mode = bool(getattr(self, "remote_mode", False))
+
+        if remote_mode:
+            receiver = getattr(self, "_remote_receiver", None)
+            if receiver is None:
+                return {
+                    "enabled": bool(self.enable_input_stats),
+                    "status": "remote_unavailable",
+                    "detail": "远程模式接收服务未初始化",
+                    "presence_status": "disabled",
+                    "presence_label": "远程在场未知",
+                    "presence_detail": "远程接收服务未初始化，离开自动挂起不会依据本机历史输入统计。",
+                    "idle_seconds": 0,
+                    "idle_label": "",
+                    "latest_event_at": "",
+                }
+
+            clients = len(getattr(receiver, "_connected_clients", set()) or set())
+            has_shot = bool(getattr(receiver, "has_screenshot", False))
+            age = float(getattr(receiver, "latest_age_seconds", float("inf")) or float("inf"))
+            max_age = max(5, int(getattr(self, "remote_screenshot_max_age", 60) or 60))
+            idle_seconds = 0 if age == float("inf") else max(0, int(age))
+            idle_label = self._format_elapsed_seconds(idle_seconds) if idle_seconds > 0 else ""
+
+            if clients > 0 and has_shot and age <= max_age:
+                return {
+                    "enabled": bool(self.enable_input_stats),
+                    "status": "remote_active",
+                    "detail": f"远程客户端在线，最近截图约 {idle_label or '刚刚'}",
+                    "presence_status": "active",
+                    "presence_label": "远程客户端在线",
+                    "presence_detail": (
+                        f"远程客户端已连接且截图新鲜（约 {idle_label or '刚刚'}），"
+                        "按远程在场处理，不使用本机陈旧输入统计。"
+                    ),
+                    "idle_seconds": idle_seconds,
+                    "idle_label": idle_label,
+                    "latest_event_at": "",
+                }
+
+            if clients > 0 and (not has_shot or age > max_age):
+                return {
+                    "enabled": bool(self.enable_input_stats),
+                    "status": "remote_waiting",
+                    "detail": "远程客户端已连接，等待新鲜截图",
+                    "presence_status": "active",
+                    "presence_label": "远程等待截图",
+                    "presence_detail": "远程客户端在线但截图尚未就绪/已过期，暂不触发离开挂起。",
+                    "idle_seconds": idle_seconds if has_shot else 0,
+                    "idle_label": idle_label,
+                    "latest_event_at": "",
+                }
+
+            return {
+                "enabled": bool(self.enable_input_stats),
+                "status": "remote_offline",
+                "detail": "远程客户端未连接",
+                "presence_status": "disabled",
+                "presence_label": "远程客户端离线",
+                "presence_detail": "远程客户端未连接，离开自动挂起已禁用，避免用本机陈旧输入统计误挂起。",
+                "idle_seconds": 0,
+                "idle_label": "",
+                "latest_event_at": "",
+            }
+
         last_event_at = str(getattr(self, "_input_stats_last_event_at", "") or "").strip()
         if not last_event_at:
             last_event_at = self._refresh_input_stats_last_event_at()
@@ -403,7 +534,6 @@ class ScreenCompanionInputStatsMixin:
             **presence,
         }
 
-    @staticmethod
     def _format_move_distance(move_pixels: int | float) -> str:
         pixels = max(0, int(move_pixels or 0))
         if pixels >= 10000:

--- a/core/media.py
+++ b/core/media.py
@@ -1860,6 +1860,23 @@ class ScreenCompanionMediaMixin:
     def _get_microphone_volume(self):
         """读取当前麦克风音量。"""
         self._ensure_runtime_state()
+        # Remote mode: use the latest volume pushed by desktop client.
+        try:
+            remote_mode = bool(
+                self._get_runtime_flag("remote_mode")
+                if hasattr(self, "_get_runtime_flag")
+                else getattr(self, "remote_mode", False)
+            )
+        except Exception:
+            remote_mode = bool(getattr(self, "remote_mode", False))
+        if remote_mode:
+            volume = int(getattr(self, "_remote_mic_volume", 0) or 0)
+            ts = float(getattr(self, "_remote_mic_timestamp", 0.0) or 0.0)
+            max_age = max(5, int(getattr(self, "remote_screenshot_max_age", 60) or 60))
+            if ts > 0 and (time.time() - ts) <= max_age:
+                return min(100, max(0, volume))
+            return 0
+
         p = None
         stream = None
         try:
@@ -1935,8 +1952,116 @@ class ScreenCompanionMediaMixin:
                 except Exception:
                     pass
 
+    def _apply_remote_mic_volume(self, volume: int, payload: dict | None = None) -> None:
+        """Store remote mic volume and optionally trigger the same high-volume path."""
+        self._ensure_runtime_state()
+        vol = min(100, max(0, int(volume or 0)))
+        self._remote_mic_volume = vol
+        self._remote_mic_timestamp = time.time()
+        if not bool(getattr(self, "enable_mic_monitor", False)):
+            return
+        try:
+            threshold = int(getattr(self, "mic_threshold", 60) or 60)
+            debounce = float(getattr(self, "mic_debounce_time", 30) or 30)
+            now = time.time()
+            last = float(getattr(self, "last_mic_trigger", 0.0) or 0.0)
+            if vol > threshold and (now - last) >= debounce:
+                self._safe_create_task(
+                    self._handle_remote_mic_trigger(vol),
+                    name="remote_mic_trigger",
+                )
+        except Exception as e:
+            logger.debug(f"远程麦克风触发检查失败: {e}")
+
+    async def _handle_remote_mic_trigger(self, volume: int) -> None:
+        self._ensure_runtime_state()
+        if not bool(getattr(self, "enable_mic_monitor", False)):
+            return
+        now = time.time()
+        last = float(getattr(self, "last_mic_trigger", 0.0) or 0.0)
+        debounce = float(getattr(self, "mic_debounce_time", 30) or 30)
+        if now - last < debounce:
+            return
+        threshold = int(getattr(self, "mic_threshold", 60) or 60)
+        if int(volume or 0) <= threshold:
+            return
+        self.last_mic_trigger = now
+        logger.info(f"远程麦克风音量超过阈值: {volume} > {threshold}")
+        ok, err_msg = self._check_env(check_mic=False)
+        if not ok:
+            logger.error(f"远程麦克风触发失败: {err_msg}")
+            return
+        try:
+            current_state = self.state
+            if current_state == "inactive":
+                self.state = "temporary"
+            temp_task_id = f"temp_mic_remote_{int(time.time())}"
+
+            async def temp_mic_task():
+                background_job_started = False
+                try:
+                    background_job_started, skip_reason = self._try_begin_background_screen_job()
+                    if not background_job_started:
+                        logger.info(f"[{temp_task_id}] 跳过远程麦克风触发识屏: {skip_reason}")
+                        return
+                    target = self._resolve_proactive_target()
+                    event = self._create_virtual_event(target)
+                    capture_timeout = self._get_capture_context_timeout(
+                        "video" if self._use_screen_recording_mode() else "image"
+                    )
+                    capture_context = await asyncio.wait_for(
+                        self._capture_proactive_recognition_context(),
+                        timeout=capture_timeout,
+                    )
+                    active_window_title = capture_context.get("active_window_title", "")
+                    components = await asyncio.wait_for(
+                        self._analyze_screen(
+                            capture_context,
+                            session=event,
+                            active_window_title=active_window_title,
+                            custom_prompt="刚才那边好像有点动静？让我看看你现在在做什么呢。",
+                            task_id=temp_task_id,
+                        ),
+                        timeout=self._get_screen_analysis_timeout(
+                            capture_context.get("media_kind", "image")
+                        ),
+                    )
+                    target = self._resolve_proactive_target()
+                    if target and await self._send_component_text(target, components):
+                        logger.info("远程麦克风提醒消息发送成功")
+                        if capture_context.get("_rest_reminder_planned"):
+                            self._mark_rest_reminder_sent(
+                                capture_context.get("_rest_reminder_info", {}) or {}
+                            )
+                except Exception as exc:
+                    logger.error(f"[{temp_task_id}] 远程麦克风触发识屏失败: {exc}")
+                finally:
+                    if temp_task_id in getattr(self, "temporary_tasks", {}):
+                        try:
+                            del self.temporary_tasks[temp_task_id]
+                        except Exception:
+                            pass
+                    if background_job_started:
+                        self._finish_background_screen_job()
+                    if not self.auto_tasks and not getattr(self, "temporary_tasks", {}):
+                        self.state = current_state
+
+            if not hasattr(self, "temporary_tasks") or self.temporary_tasks is None:
+                self.temporary_tasks = {}
+            self.temporary_tasks[temp_task_id] = asyncio.create_task(temp_mic_task())
+            logger.info(f"已创建远程麦克风临时任务: {temp_task_id}")
+        except Exception as e:
+            logger.error(f"创建远程麦克风临时任务失败: {e}")
+
     def _ensure_mic_monitor_background_task(self) -> None:
         self._ensure_runtime_state()
+        # Remote mode receives mic volume from desktop client; skip local pyaudio loop.
+        try:
+            if bool(self._get_runtime_flag("remote_mode") if hasattr(self, "_get_runtime_flag") else getattr(self, "remote_mode", False)):
+                self._stop_mic_monitor_background_task()
+                return
+        except Exception:
+            pass
         task = getattr(self, "_mic_monitor_background_task", None)
         if task and not task.done():
             return
@@ -2839,48 +2964,16 @@ class ScreenCompanionMediaMixin:
         return True, ""
 
     def _check_env(self, check_mic=False):
-        """Check whether the desktop environment is available.
+        """Check whether the desktop/remote capture environment is available.
 
         Args:
             check_mic: Whether microphone-related dependencies are required.
         """
-        dep_ok, dep_msg = self._check_dependencies(check_mic=check_mic)
-        if not dep_ok:
-            return False, dep_msg
-
+        # Route through mode-aware helpers so remote_mode skips local DISPLAY/pyautogui.
         if self._use_screen_recording_mode():
-            if not self._is_recording_platform_supported():
-                return False, self._unsupported_recording_platform_message()
-            ffmpeg_path = self._get_ffmpeg_path()
-            if not ffmpeg_path:
-                return (
-                    False,
-                    self._get_ffmpeg_missing_message()
-                )
-            return True, ""
+            return self._check_recording_env(check_mic=check_mic)
+        return self._check_screenshot_env(check_mic=check_mic)
 
-        try:
-            import pyautogui
-
-            # 检查 Linux 下的 Display 环境变量
-            if sys.platform.startswith("linux"):
-                import os
-
-                if not os.environ.get("DISPLAY") and not os.environ.get(
-                    "WAYLAND_DISPLAY"
-                ):
-                    return (
-                        False,
-                        "Detected Linux without an available graphical display. Please run it in a desktop session or with X11 forwarding.",
-                    )
-
-            size = pyautogui.size()
-            if size[0] <= 0 or size[1] <= 0:
-                return False, "Unable to capture the screen properly."
-
-            return True, ""
-        except Exception as e:
-            return False, f"自我检查失败: {str(e)}"
 
     async def _get_persona_prompt(self, umo: str = None) -> str:
         """获取屏幕伴侣的系统提示词"""

--- a/core/remote_receiver.py
+++ b/core/remote_receiver.py
@@ -26,14 +26,25 @@ class RemoteScreenReceiver:
     MAX_SCREENSHOT_BYTES = 10 * 1024 * 1024
     MAX_WEBSOCKET_MESSAGE_BYTES = 14 * 1024 * 1024
 
-    def __init__(self, *, port: int = 6315, auth_token: str = ""):
+    def __init__(
+        self,
+        *,
+        port: int = 6315,
+        auth_token: str = "",
+        on_input_stats=None,
+        on_mic_volume=None,
+    ):
         self.port = min(65535, max(1, int(port or 6315)))
         self.auth_token = str(auth_token or "").strip()
+        self._on_input_stats = on_input_stats
+        self._on_mic_volume = on_mic_volume
         self._server = None
         self._latest_image_bytes: bytes = b""
         self._latest_window_title: str = ""
         self._latest_meta: dict[str, Any] = {}
         self._latest_timestamp: float = 0.0
+        self._latest_mic_volume: int = 0
+        self._latest_mic_timestamp: float = 0.0
         self._connected_clients: set = set()
         self._lock = asyncio.Lock()
 
@@ -58,6 +69,9 @@ class RemoteScreenReceiver:
                 self._latest_window_title,
                 dict(self._latest_meta),
             )
+
+    def get_latest_mic_volume(self) -> tuple[int, float]:
+        return int(self._latest_mic_volume or 0), float(self._latest_mic_timestamp or 0.0)
 
     async def start(self) -> None:
         if self.is_running:
@@ -197,6 +211,60 @@ class RemoteScreenReceiver:
                 self._latest_timestamp = time.time()
             await websocket.send(json.dumps({"status": "screenshot_received"}))
             logger.debug(f"收到 bundle 截图: {len(jpeg_bytes)} bytes")
+            return
+
+        if msg_type in {"input_stats", "input"}:
+            payload = {
+                "keys": max(0, int(data.get("keys", 0) or 0)),
+                "clicks": max(0, int(data.get("clicks", 0) or 0)),
+                "scroll_steps": max(0, int(data.get("scroll_steps", 0) or 0)),
+                "moves": max(0, int(data.get("moves", 0) or 0)),
+                "move_pixels": max(0, int(data.get("move_pixels", 0) or 0)),
+                "window_title": str(data.get("window_title", "") or ""),
+                "timestamp": data.get("timestamp", time.time()),
+                "client_id": str(data.get("client_id", "") or ""),
+            }
+            handler = self._on_input_stats
+            if callable(handler):
+                try:
+                    result = handler(payload)
+                    if asyncio.iscoroutine(result):
+                        await result
+                except Exception as e:
+                    logger.warning(f"处理远程 input_stats 失败: {e}")
+                    await websocket.send(json.dumps({"error": f"input_stats 处理失败: {e}"}))
+                    return
+            await websocket.send(json.dumps({"status": "input_stats_received"}))
+            logger.debug(
+                "收到远程 input_stats: keys=%s clicks=%s scroll=%s moves=%s",
+                payload["keys"],
+                payload["clicks"],
+                payload["scroll_steps"],
+                payload["moves"],
+            )
+            return
+
+        if msg_type in {"mic_volume", "mic"}:
+            try:
+                volume = int(float(data.get("volume", 0) or 0))
+            except Exception:
+                volume = 0
+            volume = min(100, max(0, volume))
+            async with self._lock:
+                self._latest_mic_volume = volume
+                self._latest_mic_timestamp = time.time()
+            handler = self._on_mic_volume
+            if callable(handler):
+                try:
+                    result = handler(volume, data if isinstance(data, dict) else {})
+                    if asyncio.iscoroutine(result):
+                        await result
+                except Exception as e:
+                    logger.warning(f"处理远程 mic_volume 失败: {e}")
+                    await websocket.send(json.dumps({"error": f"mic_volume 处理失败: {e}"}))
+                    return
+            await websocket.send(json.dumps({"status": "mic_volume_received", "volume": volume}))
+            logger.debug("收到远程 mic_volume: %s", volume)
             return
 
         await websocket.send(json.dumps({"error": f"未知消息类型: {msg_type}"}))

--- a/main.py
+++ b/main.py
@@ -633,7 +633,30 @@ class ScreenCompanion(ScreenCompanionProactiveMixin, ScreenCompanionRuntimeMixin
         self._remote_receiver = RemoteScreenReceiver(
             port=min(65535, max(1, int(getattr(self, "remote_ws_port", 6315) or 6315))),
             auth_token=str(getattr(self, "remote_auth_token", "") or ""),
+            on_input_stats=self._on_remote_input_stats,
+            on_mic_volume=self._on_remote_mic_volume,
         )
+
+    def _on_remote_input_stats(self, payload: dict) -> None:
+        if not bool(getattr(self, "enable_input_stats", False)):
+            return
+        try:
+            applied = self._ingest_remote_input_stats(payload)
+            logger.info(
+                "远程输入统计已入账: keys=%s clicks=%s scroll=%s moves=%s",
+                applied.get("keys", 0),
+                applied.get("clicks", 0),
+                applied.get("scroll_steps", 0),
+                applied.get("moves", 0),
+            )
+        except Exception as e:
+            logger.warning(f"远程输入统计入账失败: {e}")
+
+    def _on_remote_mic_volume(self, volume: int, payload: dict | None = None) -> None:
+        try:
+            self._apply_remote_mic_volume(volume, payload if isinstance(payload, dict) else {})
+        except Exception as e:
+            logger.warning(f"远程麦克风音量处理失败: {e}")
 
     async def _sync_remote_receiver_runtime(self) -> None:
         enabled = self._get_runtime_flag("remote_mode")
@@ -665,6 +688,8 @@ class ScreenCompanion(ScreenCompanionProactiveMixin, ScreenCompanionRuntimeMixin
         receiver = RemoteScreenReceiver(
             port=desired_port,
             auth_token=desired_token,
+            on_input_stats=self._on_remote_input_stats,
+            on_mic_volume=self._on_remote_mic_volume,
         )
         self._remote_receiver = receiver
         await receiver.start()


### PR DESCRIPTION
## Summary
- Accept remote desktop client `input_stats` / `mic_volume` WebSocket messages in `RemoteScreenReceiver`, and wire them into plugin daily input counters + remote mic volume handling.
- Make away-auto-pause presence remote-aware: use remote client online/screenshot freshness instead of stale local keyboard history, so `/kps` no longer immediately auto-suspends in remote mode.
- Route `_check_env` through remote/recording-aware helpers so `/kps` does not fail on container `DISPLAY` when `remote_mode` is enabled.
- Skip local `pyaudio` mic loop under remote mode; high remote volume can still trigger recognition.

## Test plan
- [x] Local WS probe: auth + `input_stats` returns `input_stats_received` and updates `input_stats_daily.json`
- [x] Local WS probe: `mic_volume` returns `mic_volume_received` and logs remote threshold trigger when above `mic_threshold`
- [ ] Desktop client reconnect after plugin reload; confirm server logs `远程输入统计已入账`
- [ ] `/kps` starts without `DISPLAY` self-check failure in remote mode
- [ ] With remote client connected and screenshots flowing, away-auto-pause does not immediately suspend
- [ ] High remote `mic_volume` above threshold can create remote mic temporary recognition task