### PR TITLE
fix: preserve event context for screen tools

### DIFF
--- a/main.py
+++ b/main.py
@@ -173,14 +173,14 @@ class ScreenPeekTool(FunctionTool[AstrAgentContext]):
 
         allowed, denial_message = await _ensure_tool_admin_permission(
             plugin,
-            context.context,
+            context,
             tool_name=self.name,
         )
         if not allowed:
             return denial_message
 
         question = str(kwargs.get("question", "") or "").strip()
-        event = _get_tool_event(context.context)
+        event = _get_tool_event(context)
         try:
             capture_context = await plugin._capture_recognition_context()
             active_window_title = str(capture_context.get("active_window_title", "") or "")
@@ -237,7 +237,7 @@ class ScreenUsageContextTool(FunctionTool[AstrAgentContext]):
 
         allowed, denial_message = await _ensure_tool_admin_permission(
             plugin,
-            context.context,
+            context,
             tool_name=self.name,
         )
         if not allowed:


### PR DESCRIPTION
## 问题

在 AstrBot 4.26.5 中，通过自然语言调用 `screen_peek` 时，插件提前将完整的 `ContextWrapper` 剥离为 `context.context`，导致部分调用链无法取得事件对象，并按安全策略返回权限不足。

`/kp` 直接使用消息事件，因此不受影响。

## 修复

- 将完整 `ContextWrapper` 传给工具权限检查。
- 从同一完整上下文解析截图分析所需的事件。
- 同步修复 `screen_usage_context` 的相同问题。
- 保持无法取得事件时默认拒绝，不放宽管理员或私聊限制。

## 验证

在 AstrBot 4.26.5、管理员私聊场景中验证：

- `/kp` 正常识屏。
- 自然语言调用 `screen_peek` 正常识屏。
- 日志进入“开始分析当前识屏素材”。
- 不再出现“未获得事件上下文”或“权限不足”。